### PR TITLE
To support strings as lists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,19 @@ function isList(list) {
 }
 
 /**
+ * Retorna verdadero si el objeto de entrada es una cadena de texto
+ * @param {String} str
+ * @returns {boolean} 
+ * @example isString(""); // => true
+ * @example isString([1, 2]); // => false
+ * @example isString(1); // => false
+ * @example isString("Hola"); // => true
+ */
+function isString(str) {
+    return typeof str === 'string' && typeof str.length == 'number' && str.length >= 0;
+}
+
+/**
  * Retorna la longitud de un arreglo
  * @param {Array} list 
  * @returns {Number}

--- a/src/index.js
+++ b/src/index.js
@@ -37,10 +37,13 @@ function rest(list) {
  * @returns {boolean}
  * @example isEmpty([1, 2, 3]); // => false
  * @example isEmpty([]); // => true
-
+ * @example isEmpty(""); // => true
  */
 function isEmpty(list) {
     if (typeof list == 'object') {
+        return list.length === 0;
+    }
+    if (typeof list == 'string') {
         return list.length === 0;
     }
     return false;


### PR DESCRIPTION
We can work with lists and strings. A common lists contain a number of items and common string contain a number of characters. Both can be treated as list ADT where:

- "" is empty string.
- " " is one element string, whitespaces also treated as characters. 
- "abcd" is similar to cons('a', cons('b', cons('c', cons('d', empty))))

strings and lists behave so similarly.